### PR TITLE
Avoid `llvm-ar` bug by using binutils `ar` everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     - BINARYBUILDER_DOWNLOADS_CACHE=downloads
-    - BINARYBUILDER_AUTOMATIC_APPLE=false
+    - BINARYBUILDER_AUTOMATIC_APPLE=true
 sudo: required
 
 # Before anything else, get the latest versions of things

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -19,7 +19,6 @@ cd $WORKSPACE/srcdir/gsl-*/
 ./configure --prefix=$prefix --host=${target}
 make -j${nproc}
 make install
-
 """
 
 # These are the platforms we will build for by default, unless further

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+AR=/opt/${target}/bin/ar
 cd $WORKSPACE/srcdir/gsl-*/
 ./configure --prefix=$prefix --host=${target}
 make -j${nproc}
@@ -23,20 +24,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64)
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products(prefix) = [


### PR DESCRIPTION
Also build for all supported platforms

Fix #1 